### PR TITLE
Fixed #2 -- refactored printk to not need to malloc 

### DIFF
--- a/src/printk.rs
+++ b/src/printk.rs
@@ -5,13 +5,23 @@ use types::c_int;
 pub struct KernelConsole;
 
 extern "C" {
-    fn printk_helper(s: *const u8, len: c_int) -> c_int;
+    fn printk_info_helper(s: *const u8, len: c_int) -> c_int;
+    fn printk_cont_helper(s: *const u8, len: c_int) -> c_int;
+}
+
+fn printk_info(s: &str) {
+    // TODO: I believe printk never fails
+    unsafe { printk_info_helper(s.as_ptr(), s.len() as c_int) };
+}
+
+fn printk_cont(s: &str) {
+    // TODO: I believe printk never fails
+    unsafe { printk_cont_helper(s.as_ptr(), s.len() as c_int) };
 }
 
 impl fmt::Write for KernelConsole {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        // TODO: I believe printk never fails
-        unsafe { printk_helper(s.as_ptr(), s.len() as c_int) };
+        printk_cont(s);
         Ok(())
     }
 }
@@ -19,17 +29,14 @@ impl fmt::Write for KernelConsole {
 #[macro_export]
 macro_rules! println {
     () => ({
-        use ::core::fmt::Write;
-        let _ = $crate::printk::KernelConsole.write_str("\x016\n");
+        $crate::printk::printk_info("\n");
     });
     ($fmt:expr) => ({
-        use ::core::fmt::Write;
-        let _ = $crate::printk::KernelConsole.write_str(concat!("\x016", $fmt, "\n"));
+        $crate::printk::printk_info(concat!($fmt, "\n"));
     });
     ($fmt:expr, $($arg:tt)*) => ({
         use ::core::fmt::Write;
-        // TODO: Don't allocate!
-        let s = format!(concat!("\x016", $fmt, "\n"), $($arg)*);
-        let _ = $crate::printk::KernelConsole.write_str(&s);
+        $crate::printk::printk_info("");
+        let _ = $crate::printk::KernelConsole.write_fmt(format_args!(concat!($fmt, "\n"), $($args)*);
     });
 }

--- a/src/printk.rs
+++ b/src/printk.rs
@@ -9,12 +9,12 @@ extern "C" {
     fn printk_cont_helper(s: *const u8, len: c_int) -> c_int;
 }
 
-fn printk_info(s: &str) {
+pub fn printk_info(s: &str) {
     // TODO: I believe printk never fails
     unsafe { printk_info_helper(s.as_ptr(), s.len() as c_int) };
 }
 
-fn printk_cont(s: &str) {
+pub fn printk_cont(s: &str) {
     // TODO: I believe printk never fails
     unsafe { printk_cont_helper(s.as_ptr(), s.len() as c_int) };
 }
@@ -37,6 +37,6 @@ macro_rules! println {
     ($fmt:expr, $($arg:tt)*) => ({
         use ::core::fmt::Write;
         $crate::printk::printk_info("");
-        let _ = $crate::printk::KernelConsole.write_fmt(format_args!(concat!($fmt, "\n"), $($args)*));
+        let _ = $crate::printk::KernelConsole.write_fmt(format_args!(concat!($fmt, "\n"), $($arg)*));
     });
 }

--- a/src/printk.rs
+++ b/src/printk.rs
@@ -37,6 +37,6 @@ macro_rules! println {
     ($fmt:expr, $($arg:tt)*) => ({
         use ::core::fmt::Write;
         $crate::printk::printk_info("");
-        let _ = $crate::printk::KernelConsole.write_fmt(format_args!(concat!($fmt, "\n"), $($args)*);
+        let _ = $crate::printk::KernelConsole.write_fmt(format_args!(concat!($fmt, "\n"), $($args)*));
     });
 }

--- a/src/printk_helper.c
+++ b/src/printk_helper.c
@@ -2,10 +2,10 @@
 
 int printk_info_helper(const unsigned char *s, int len)
 {
-	return printk(KERNEL_INFO "%.*s", len, (const char *)s);
+	return printk(KERN_INFO "%.*s", len, (const char *)s);
 }
 
 int printk_cont_helper(const unsigned char *s, int len)
 {
-	return printk(KERNEL_CONT "%.*s", len, (const char *)s);
+	return printk(KERN_CONT "%.*s", len, (const char *)s);
 }

--- a/src/printk_helper.c
+++ b/src/printk_helper.c
@@ -1,6 +1,11 @@
 #include <linux/printk.h>
 
-int printk_helper(const unsigned char *s, int len)
+int printk_info_helper(const unsigned char *s, int len)
 {
-	return printk("%.*s", len, (const char *)s);
+	return printk(KERNEL_INFO "%.*s", len, (const char *)s);
+}
+
+int printk_cont_helper(const unsigned char *s, int len)
+{
+	return printk(KERNEL_CONT "%.*s", len, (const char *)s);
 }


### PR DESCRIPTION
Instead we make multiple calls to printk, leveraging KERNEL_CONT. In the common case we still only have a single call to it.
