### PR TITLE
Fixed #2 -- use a stack buffer for formatting strings in printk

### DIFF
--- a/src/printk.rs
+++ b/src/printk.rs
@@ -47,16 +47,15 @@ impl fmt::Write for LogLineWriter {
 #[macro_export]
 macro_rules! println {
     () => ({
-        $crate::printk::printk("\x016\n".as_bytes());
+        $crate::printk::printk("\n".as_bytes());
     });
     ($fmt:expr) => ({
-        $crate::printk::printk(concat!("\x016", $fmt, "\n").as_bytes());
+        $crate::printk::printk(concat!($fmt, "\n").as_bytes());
     });
     ($fmt:expr, $($arg:tt)*) => ({
         use ::core::fmt;
         let mut writer = $crate::printk::LogLineWriter::new();
-        // TODO: Don't allocate!
-        let _ = fmt::write(&mut writer, format_args!(concat!("\x016", $fmt, "\n"), $($arg)*)).unwrap();
+        let _ = fmt::write(&mut writer, format_args!(concat!($fmt, "\n"), $($arg)*)).unwrap();
         $crate::printk::printk(writer.as_bytes());
     });
 }

--- a/src/printk.rs
+++ b/src/printk.rs
@@ -16,20 +16,20 @@ pub fn printk(s: &[u8]) {
 // From kernel/print/printk.c 
 const LOG_LINE_MAX: usize = 1024 - 32;
 
-struct LogLineWriter {
+pub struct LogLineWriter {
     data: [u8; LOG_LINE_MAX],
     pos: usize,
 }
 
 impl LogLineWriter {
-    fn new() -> LogLineWriter {
+    pub fn new() -> LogLineWriter {
         LogLineWriter{
             data: [0u8; LOG_LINE_MAX],
             pos: 0,
         }
     }
     
-    fn as_bytes(&self) -> &[u8] {
+    pub fn as_bytes(&self) -> &[u8] {
         return &self.data;
     }
 }
@@ -61,7 +61,7 @@ macro_rules! println {
         use ::core::fmt::Write;
         let mut writer = LogLineWriter::new();
         // TODO: Don't allocate!
-        let _ = write!(&mut writer, format_args!(concat!("\x016", $fmt, "\n"), $($arg)*)).unwrap();
+        let _ = fmt::write(&mut writer, format_args!(concat!("\x016", $fmt, "\n"), $($arg)*)).unwrap();
         $crate::printk::printk(writer.as_bytes());
     });
 }

--- a/src/printk.rs
+++ b/src/printk.rs
@@ -36,12 +36,12 @@ impl LogLineWriter {
 
 impl fmt::Write for LogLineWriter {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        let copy_len = if LOG_LINE_MAX - pos >= s.as_bytes().len() {
+        let copy_len = if LOG_LINE_MAX - self.pos >= s.as_bytes().len() {
             s.as_bytes().len()
         } else {
-            LOG_LINE_MAX - pos
+            LOG_LINE_MAX - self.pos
         };
-        self.data[self.pos..self.pos+copy_len].copy_from_slice(s.as_bytes()[..copy_len]);
+        self.data[self.pos..self.pos+copy_len].copy_from_slice(&s.as_bytes()[..copy_len]);
         self.pos += copy_len;
         return Ok(());
     }

--- a/src/printk.rs
+++ b/src/printk.rs
@@ -56,7 +56,7 @@ macro_rules! println {
         $crate::printk::printk(concat!("\x016", $fmt, "\n").as_bytes());
     });
     ($fmt:expr, $($arg:tt)*) => ({
-        use ::core::fmt::{self, Write};
+        use ::core::fmt;
         let mut writer = $crate::printk::LogLineWriter::new();
         // TODO: Don't allocate!
         let _ = fmt::write(&mut writer, format_args!(concat!("\x016", $fmt, "\n"), $($arg)*)).unwrap();

--- a/src/printk.rs
+++ b/src/printk.rs
@@ -1,3 +1,4 @@
+use core::cmp;
 use core::fmt;
 
 use types::c_int;
@@ -36,11 +37,7 @@ impl LogLineWriter {
 
 impl fmt::Write for LogLineWriter {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        let copy_len = if LOG_LINE_MAX - self.pos >= s.as_bytes().len() {
-            s.as_bytes().len()
-        } else {
-            LOG_LINE_MAX - self.pos
-        };
+        let copy_len = cmp::min(LOG_LINE_MAX - self.pos, s.as_bytes().len());
         self.data[self.pos..self.pos + copy_len].copy_from_slice(&s.as_bytes()[..copy_len]);
         self.pos += copy_len;
         return Ok(());

--- a/src/printk.rs
+++ b/src/printk.rs
@@ -13,7 +13,7 @@ pub fn printk(s: &[u8]) {
     unsafe { printk_helper(s.as_ptr(), s.len() as c_int) };
 }
 
-// From kernel/print/printk.c 
+// From kernel/print/printk.c
 const LOG_LINE_MAX: usize = 1024 - 32;
 
 pub struct LogLineWriter {
@@ -23,12 +23,12 @@ pub struct LogLineWriter {
 
 impl LogLineWriter {
     pub fn new() -> LogLineWriter {
-        LogLineWriter{
+        LogLineWriter {
             data: [0u8; LOG_LINE_MAX],
             pos: 0,
         }
     }
-    
+
     pub fn as_bytes(&self) -> &[u8] {
         return &self.data[..self.pos];
     }
@@ -41,7 +41,7 @@ impl fmt::Write for LogLineWriter {
         } else {
             LOG_LINE_MAX - self.pos
         };
-        self.data[self.pos..self.pos+copy_len].copy_from_slice(&s.as_bytes()[..copy_len]);
+        self.data[self.pos..self.pos + copy_len].copy_from_slice(&s.as_bytes()[..copy_len]);
         self.pos += copy_len;
         return Ok(());
     }

--- a/src/printk.rs
+++ b/src/printk.rs
@@ -59,7 +59,7 @@ macro_rules! println {
     });
     ($fmt:expr, $($arg:tt)*) => ({
         use ::core::fmt::Write;
-        let mut writer = LogLineWriter::new();
+        let mut writer = $crate::printk::LogLineWriter::new();
         // TODO: Don't allocate!
         let _ = fmt::write(&mut writer, format_args!(concat!("\x016", $fmt, "\n"), $($arg)*)).unwrap();
         $crate::printk::printk(writer.as_bytes());

--- a/src/printk.rs
+++ b/src/printk.rs
@@ -50,11 +50,9 @@ impl fmt::Write for LogLineWriter {
 #[macro_export]
 macro_rules! println {
     () => ({
-        use ::core::fmt::Write;
         $crate::printk::printk("\x016\n".as_bytes());
     });
     ($fmt:expr) => ({
-        use ::core::fmt::Write;
         $crate::printk::printk(concat!("\x016", $fmt, "\n").as_bytes());
     });
     ($fmt:expr, $($arg:tt)*) => ({

--- a/src/printk.rs
+++ b/src/printk.rs
@@ -58,7 +58,7 @@ macro_rules! println {
         $crate::printk::printk(concat!("\x016", $fmt, "\n").as_bytes());
     });
     ($fmt:expr, $($arg:tt)*) => ({
-        use ::core::fmt::Write;
+        use ::core::fmt::{self, Write};
         let mut writer = $crate::printk::LogLineWriter::new();
         // TODO: Don't allocate!
         let _ = fmt::write(&mut writer, format_args!(concat!("\x016", $fmt, "\n"), $($arg)*)).unwrap();

--- a/src/printk.rs
+++ b/src/printk.rs
@@ -30,7 +30,7 @@ impl LogLineWriter {
     }
     
     pub fn as_bytes(&self) -> &[u8] {
-        return &self.data;
+        return &self.data[..self.pos];
     }
 }
 

--- a/src/printk.rs
+++ b/src/printk.rs
@@ -18,7 +18,7 @@ const LOG_LINE_MAX: usize = 1024 - 32;
 
 struct LogLineWriter {
     data: [u8; LOG_LINE_MAX],
-    pos: usize;
+    pos: usize,
 }
 
 impl LogLineWriter {
@@ -40,8 +40,9 @@ impl fmt::Write for LogLineWriter {
             s.as_bytes().len()
         } else {
             LOG_LINE_MAX - pos
-        }
-        self.data[pos..pos+copy_len].copy_from_slice(s.as_bytes()[..copy_len]);
+        };
+        self.data[self.pos..self.pos+copy_len].copy_from_slice(s.as_bytes()[..copy_len]);
+        self.pos += copy_len;
         return Ok(());
     }
 }

--- a/src/printk_helper.c
+++ b/src/printk_helper.c
@@ -2,5 +2,5 @@
 
 int printk_helper(const unsigned char *s, int len)
 {
-	return printk("%.*s", len, (const char *)s);
+	return printk(KERN_INFO "%.*s", len, (const char *)s);
 }


### PR DESCRIPTION
This avoids a malloc