### PR TITLE
Remove `eh_personality` lang item

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,9 +68,6 @@ extern "C" {
     fn bug_helper() -> !;
 }
 
-#[lang = "eh_personality"]
-extern "C" fn eh_personality() {}
-
 #[lang = "panic_fmt"]
 extern "C" fn panic_fmt() -> ! {
     unsafe {


### PR DESCRIPTION
See https://github.com/alex/linux-kernel-module-rust/pull/19#issuecomment-392351011
for why we can do this - basically, since every crate is compiled with
panic=abort (using cargo xbuild), the compiler should not generate any
code that needs a personality function.