### PR TITLE
Remove LDFLAG for gcing sections

### DIFF
--- a/hello-world/Makefile
+++ b/hello-world/Makefile
@@ -1,6 +1,6 @@
 obj-m := helloworld.o
 helloworld-objs := target/x86_64-linux-kernel-module/debug/libhello_world.a
-EXTRA_LDFLAGS += --gc-sections --entry=init_module --undefined=cleanup_module
+EXTRA_LDFLAGS += --entry=init_module
 
 all:
 	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(CURDIR)

--- a/static-filesystem/Makefile
+++ b/static-filesystem/Makefile
@@ -1,6 +1,6 @@
 obj-m := staticfilesystem.o
 staticfilesystem-objs := target/x86_64-linux-kernel-module/debug/libstatic_filesystem.a
-EXTRA_LDFLAGS += --gc-sections --entry=init_module --undefined=cleanup_module
+EXTRA_LDFLAGS += --entry=init_module
 
 all:
 	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(CURDIR)


### PR DESCRIPTION
@geofft reminds me that the only reason we added it in the first place was to avoid cross compilation for as long as possible, which is 100% irrelevant now