### PR TITLE
Disable cc's warnings when compiling the helpers

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -71,6 +71,7 @@ fn main() {
     let mut builder = cc::Build::new();
     println!("cargo:rerun-if-env-changed=CLANG");
     builder.compiler(env::var("CLANG").unwrap_or("clang".to_string()));
+    builder.warnings(false);
     builder.file("src/helpers.c");
     for arg in shlex::split(&output).unwrap() {
         builder.flag(&arg);


### PR DESCRIPTION
CC adds -Wall -Wextra by default, which emits boatloads of kernel warnings I don't care about. We can just rely on whatever cflags the kernel makefiles produce