### PR TITLE
mark the printk module as macro use

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod bindings;
 mod c_types;
 mod error;
 pub mod filesystem;
+#[macro_use]
 pub mod printk;
 
 pub use error::{Error, KernelResult};


### PR DESCRIPTION
this lets you use the println!() macro inside the linux_kernel_module project (useful for debugging)