### PR TITLE
Remove `#![feature(use_extern_macros)]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![feature(alloc, global_allocator, allocator_api, const_fn, lang_items, use_extern_macros)]
+#![feature(alloc, global_allocator, allocator_api, const_fn, lang_items)]
 
 extern crate alloc;
 #[macro_use]


### PR DESCRIPTION
Also no longer needed for the same reason as f3109902 (we stopped using `format!`).