### PR TITLE
Parameterize the kernel module build dir in all makefiles.

### DIFF
--- a/example-sysctl/Makefile
+++ b/example-sysctl/Makefile
@@ -1,9 +1,10 @@
 obj-m := examplesysctl.o
 examplesysctl-objs := target/x86_64-linux-kernel-module/debug/libexample_sysctl.a
 EXTRA_LDFLAGS += --entry=init_module
+KDIR ?= /lib/modules/$(shell uname -r)/build
 
 all:
-	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(CURDIR)
+	$(MAKE) -C $(KDIR) M=$(CURDIR)
 
 clean:
-	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(CURDIR) clean
+	$(MAKE) -C $(KDIR) M=$(CURDIR) clean

--- a/hello-world/Makefile
+++ b/hello-world/Makefile
@@ -1,9 +1,10 @@
 obj-m := helloworld.o
 helloworld-objs := target/x86_64-linux-kernel-module/debug/libhello_world.a
 EXTRA_LDFLAGS += --entry=init_module
+KDIR ?= /lib/modules/$(shell uname -r)/build
 
 all:
-	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(CURDIR)
+	$(MAKE) -C $(KDIR) M=$(CURDIR)
 
 clean:
-	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(CURDIR) clean
+	$(MAKE) -C $(KDIR) M=$(CURDIR) clean

--- a/static-filesystem/Makefile
+++ b/static-filesystem/Makefile
@@ -1,9 +1,10 @@
 obj-m := staticfilesystem.o
 staticfilesystem-objs := target/x86_64-linux-kernel-module/debug/libstatic_filesystem.a
 EXTRA_LDFLAGS += --entry=init_module
+KDIR ?= /lib/modules/$(shell uname -r)/build
 
 all:
-	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(CURDIR)
+	$(MAKE) -C $(KDIR) M=$(CURDIR)
 
 clean:
-	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(CURDIR) clean
+	$(MAKE) -C $(KDIR) M=$(CURDIR) clean

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,9 +1,10 @@
 obj-m := testmodule.o
 testmodule-objs := $(TEST_LIBRARY)
 EXTRA_LDFLAGS += --entry=init_module
+KDIR ?= /lib/modules/$(shell uname -r)/build
 
 all:
-	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(CURDIR)
+	$(MAKE) -C $(KDIR) M=$(CURDIR)
 
 clean:
-	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(CURDIR) clean
+	$(MAKE) -C $(KDIR) M=$(CURDIR) clean


### PR DESCRIPTION
Builds that can target kernels besides the currently running one cannot
work when the path is hard-coded to use (uname -r).
Define KDIR parameter and set a default value if it is undefined.