### PR TITLE
Manually pass the correct target to bindgen/clang in the top-level build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -59,6 +59,7 @@ fn main() {
     )
     .unwrap();
 
+    builder = builder.clang_arg("--target=x86_64-linux-kernel-module");
     for arg in shlex::split(&output).unwrap() {
         builder = builder.clang_arg(arg.to_string());
     }
@@ -88,6 +89,7 @@ fn main() {
     let mut builder = cc::Build::new();
     println!("cargo:rerun-if-env-changed=CLANG");
     builder.compiler(env::var("CLANG").unwrap_or("clang".to_string()));
+    builder.target("x86_64-linux-kernel-module");
     builder.warnings(false);
     builder.file("src/helpers.c");
     for arg in shlex::split(&output).unwrap() {


### PR DESCRIPTION
Extracted from #67.