### PR TITLE
Makefile changes from #67

### DIFF
--- a/hello-world/Makefile
+++ b/hello-world/Makefile
@@ -1,9 +1,11 @@
+ifneq ($(KERNELRELEASE),)
 obj-m := helloworld.o
 helloworld-objs := libhello_world.o
 EXTRA_LDFLAGS += --entry=init_module
 
 $(M)/libhello_world.o: target/x86_64-linux-kernel-module/debug/libhello_world.a
 	$(LD) -r -o $@ --whole-archive $^
+else
 KDIR ?= /lib/modules/$(shell uname -r)/build
 
 all:
@@ -11,3 +13,4 @@ all:
 
 clean:
 	$(MAKE) -C $(KDIR) M=$(CURDIR) clean
+endif

--- a/hello-world/Makefile
+++ b/hello-world/Makefile
@@ -1,6 +1,9 @@
 obj-m := helloworld.o
-helloworld-objs := target/x86_64-linux-kernel-module/debug/libhello_world.a
+helloworld-objs := libhello_world.o
 EXTRA_LDFLAGS += --entry=init_module
+
+$(M)/libhello_world.o: target/x86_64-linux-kernel-module/debug/libhello_world.a
+	$(LD) -r -o $@ --whole-archive $^
 KDIR ?= /lib/modules/$(shell uname -r)/build
 
 all:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,11 @@
+ifneq ($(KERNELRELEASE),)
 obj-m := testmodule.o
 testmodule-objs := $(TEST_LIBRARY)
 EXTRA_LDFLAGS += --entry=init_module
+
+$(M)/$(TEST_LIBRARY): $(TEST_LIBRARY_ARCHIVE)
+	$(LD) -r -o $@ --whole-archive $^
+else
 KDIR ?= /lib/modules/$(shell uname -r)/build
 
 all:
@@ -8,3 +13,4 @@ all:
 
 clean:
 	$(MAKE) -C $(KDIR) M=$(CURDIR) clean
+endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,9 +1,9 @@
 ifneq ($(KERNELRELEASE),)
 obj-m := testmodule.o
-testmodule-objs := $(TEST_LIBRARY)
+testmodule-objs := $(TEST_LIBRARY_OBJECT)
 EXTRA_LDFLAGS += --entry=init_module
 
-$(M)/$(TEST_LIBRARY): $(TEST_LIBRARY_ARCHIVE)
+$(M)/$(TEST_LIBRARY_OBJECT): target/x86_64-linux-kernel-module/debug/$(TEST_LIBRARY_ARCHIVE)
 	$(LD) -r -o $@ --whole-archive $^
 else
 KDIR ?= /lib/modules/$(shell uname -r)/build

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -46,16 +46,12 @@ def main():
                 path
             )
         )
-        library_archive, _ = os.path.splitext(os.path.basename(module))
-        library_archive = library_archive + ".a"
+        library_path, _ = os.path.splitext(os.path.basename(module))
+        library_object = library_path + ".o"
+        library_archive = library_path + ".a"
         run(
             "make", "-C", BASE_DIR,
-            "TEST_LIBRARY={}".format(
-                os.path.join(
-                    "target/x86_64-linux-kernel-module/debug/",
-                    os.path.basename(module)
-                )
-            ),
+            "TEST_LIBRARY_OBJECT={}".format(library_object),
             "TEST_LIBRARY_ARCHIVE={}".format(library_archive),
         )
         run(

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -46,6 +46,8 @@ def main():
                 path
             )
         )
+        library_archive, _ = os.path.splitext(os.path.basename(module))
+        library_archive = library_archive + ".a"
         run(
             "make", "-C", BASE_DIR,
             "TEST_LIBRARY={}".format(
@@ -54,6 +56,7 @@ def main():
                     os.path.basename(module)
                 )
             ),
+            "TEST_LIBRARY_ARCHIVE={}".format(library_archive),
         )
         run(
             "rustc",


### PR DESCRIPTION
Convert the Rust `.a` file into a `.o` with `ld --relocatable`, and add a Makefile conditional to separate the user-facing entry points (`make all`, `make clean`) from the kbuild bits.