### PR TITLE
chrdev: Instead of passing a Range of minors, default to starting at 0

### DIFF
--- a/tests/chrdev/src/lib.rs
+++ b/tests/chrdev/src/lib.rs
@@ -30,7 +30,7 @@ struct ChrdevTestModule {
 
 impl linux_kernel_module::KernelModule for ChrdevTestModule {
     fn init() -> linux_kernel_module::KernelResult<Self> {
-        let chrdev_registration = linux_kernel_module::chrdev::builder("chrdev-tests\x00", 0..1)?
+        let chrdev_registration = linux_kernel_module::chrdev::builder("chrdev-tests\x00")?
             .register_device::<CycleFile>()
             .build()?;
         Ok(ChrdevTestModule {


### PR DESCRIPTION
Since we're using a builder pattern we can actually implement defaults.